### PR TITLE
Fix typo on bounty page

### DIFF
--- a/bounties.html
+++ b/bounties.html
@@ -70,7 +70,7 @@
           <h1 class="big-title">Bounties</h1>
           <h3 class="small-title" id="small-title">Earn money for helping us fix bugs and issues.</h3>
           <p class="fine-print">
-            The fine print: Bounties are denominated in US dollars and are paid in BCH, and may be changed or removed at any time. Bounties are awarded normally on a first come, first served basis, but at our sole discretion, including determining if an issue was successfully or fully resolved. You are soley responsible for any applicable taxes on your earnings. No monies paid constitute employment, partnership, joint-venture or any other business arangement. All merged code becomes part of the project under the MIT lisence.
+            The fine print: Bounties are denominated in US dollars and are paid in BCH, and may be changed or removed at any time. Bounties are awarded normally on a first come, first served basis, but at our sole discretion, including determining if an issue was successfully or fully resolved. You are soley responsible for any applicable taxes on your earnings. No monies paid constitute employment, partnership, joint-venture or any other business arangement. All merged code becomes part of the project under the MIT license.
           </p>
         </div>
       </div>


### PR DESCRIPTION
"lisence" -> "license"