### PR TITLE
Clarify exact date of SV Hard Fork

### DIFF
--- a/nov2018.html
+++ b/nov2018.html
@@ -69,7 +69,7 @@
     <div class="container">
       <div class="row">
         <div class="twelve column hero-title" style="margin-top: 10%">
-          <h1 class="big-title2">November 15th<BR>Hard Fork</h1>
+          <h1 class="big-title2">November 15th, 2018<BR>Hard Fork</h1>
           <h3 class="small-title2" id="small-title">Instructions for Safe Storage,<BR> Transfer, and Coin Splitting</h3>
 
 <div align=left>
@@ -78,7 +78,7 @@
  
 
  <p class="description" >
-            On November 15th, the Bitcoin Cash network underwet a scheduled protocol upgrade .  However, an alternate forked coin was also created (Bitcoin SV).
+            On November 15th, 2018, the Bitcoin Cash network underwet a scheduled protocol upgrade .  However, an alternate forked coin was also created (Bitcoin SV).
            
 
 


### PR DESCRIPTION
It's almost November 15th again. Unless someone looks at the URL of the page, this can be confusing as the SV hard fork page doesn't list a year.