### PR TITLE
[Feature] Add docker support for electroncash.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.7
+RUN apk add --update --no-cache curl bash
+
+FROM nginx
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY . /usr/share/nginx/html/
+
+#CMD ["bash"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen       80;
+    server_name  electroncash.org;
+
+    if ( $http_host = 'www.electroncash.org' ){
+        return 301 https://electroncash.org$request_uri;
+    }
+
+    if ( $http_x_forwarded_proto = 'http' ) {
+        return 301 https://$host$request_uri;
+    }
+    
+    root   /usr/share/nginx/html;
+
+    location / {
+        index  index.html;
+    }
+
+    location ~ \.(raw) {
+        return 404;
+    }
+
+    location ~*  \.(jpg|jpeg|png|gif|ico)$ {
+        expires 30d;
+    }
+
+    location ~*  \.(css|js)$ {
+        expires 1d;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+
+## Compression.
+gzip on;
+gzip_buffers 16 8k;
+gzip_comp_level 1;
+gzip_http_version 1.1;
+gzip_min_length 10;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+gzip_vary on;
+gzip_proxied any; # Compression for all requests.
+## No need for regexps. See
+## http://wiki.nginx.org/NginxHttpGzipModule#gzip_disable
+gzip_disable msie6;


### PR DESCRIPTION
This adds a Dockerfile and basic nginx.conf for running electroncash.org within Docker.

Note: The repo is missing a few images, they will need to be added to github for everything to work.

To build and test the image just run:

```
docker build -t electroncash .
docker run -p8080:80 electroncash 
```

Then open your browser and load up `http://localhost:8080`. Then you can see exactly how the site is looking, and can easily see the missing images in the repo. Once the content on github is updated, and we are happy with how the site looks, then we can start the process of migrating the site to my Kubernetes cluster. =)