### PR TITLE
fix display mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,16 +346,16 @@ outdated version if absolutely necessary or for research purposes.
   <div class="row">
         <div class="twelve columns">
   <h3>The Revolution Will Not Be Centralized</h3>
-         <center><img src="images/4-bitcoin-cash-logo-ot-small.png"></center>
+         <center><img style="max-width:100%;" src="images/4-bitcoin-cash-logo-ot-small.png"></center>
 
 <Hr width=50%>
-<center><a href="https://satochip.io/shop/wallet/13/?campaign=ElectronCash"><img src="images/Satochip_banner.gif"></center></a>
+<center><a href="https://satochip.io/shop/wallet/13/?campaign=ElectronCash"><img style="max-width:100%;" src="images/Satochip_banner.gif"></center></a>
 
 
 <P>
 <CENTER>
 
-<object type="image/svg+xml" data="https://rcimg.net/images/sponsors/svg/ElectronCash.svg" style="margin: auto;"></object>
+<object style="max-width:100%;" type="image/svg+xml" data="https://rcimg.net/images/sponsors/svg/ElectronCash.svg" style="margin: auto;"></object>
 
 
  
@@ -380,7 +380,7 @@ outdated version if absolutely necessary or for research purposes.
 
  <div id ="donate" class="row"> 
   
-          <p>Electron Cash development is community funded.  You can donate:<BR><B>bitcoincash:qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae</b>
+          <p style="overflow-wrap: break-word;">Electron Cash development is community funded.  You can donate:<BR><B>bitcoincash:qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae</b>
  
 <P><BR> 
 


### PR DESCRIPTION
Currently the menu-item doesn't display on mobile phones.
This is because the BCH logo, the satochip banner and the read.cash sponsorship widget all become wider than the screensize. The donation address also overflows on mobile.

This fix adds max-width:100% as inline style to the first three items and overflow-wrap to the donation address.
After these changes the menu-item displays as intended for mobile.