### PR TITLE
Show pointer cursor on menu items

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@
 
       </a><ul id="menu"><a class="hamburger-shell">
           </a><a href="index.html"> <li>Home</li></a>
-          <a id="benefits-button2"> <li>Benefits</li></a>
-          <a id="download-button2"> <li>Download</li></a>
-          <a id="faq-button2"> <li>FAQ</li></a>
+          <a href="#" id="benefits-button2"> <li>Benefits</li></a>
+          <a href="#" id="download-button2"> <li>Download</li></a>
+          <a href="#" id="faq-button2"> <li>FAQ</li></a>
       </ul>
       
   </header>


### PR DESCRIPTION
When you don't add `href` attribute the browser will not show the cursor pointer during mouse-over. (in Firefox at least)