### PR TITLE
Fix link to paper wallet

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@ outdated version if absolutely necessary or for research purposes.
       
       <div class="row">
         <h6 style="font-size: 1.75rem;">   <a href="https://bch.info/">Learn about Bitcoin Cash</a> | <a href="https://github.com/Electron-Cash/Electron-Cash">Explore Source Code</a> | <a href="http://www.reddit.com/r/btc">Uncensored Bitcoin Forum</a> |
-<a href="https://t.me/electroncashwallet">Telegram Chatroom</a> | <a href="paper">Paper Wallet</a>
+<a href="https://t.me/electroncashwallet">Telegram Chatroom</a> | <a href="https://cashaddress.org/">Paper Wallet</a>
 
         </h6>
       </div>


### PR DESCRIPTION
cashaddress.org is long-running by a trusted party (zquest), works offline and likely the best candidate for the link.